### PR TITLE
fix(global): fix version numbers for lerna publish

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.0.0-dev.0",
+  "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "version": "independent",
   "npmClient": "yarn",
-  "useWorkspaces": true,
+  "packages": ["theme"],
   "command": {
     "publish": {
       "allowBranch": "master",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-dev",
   "description": "A Gatsby theme to showcase your open-source work",
-  "version": "0.0.0-dev.0",
+  "version": "0.0.0",
   "license": "MIT",
   "main": "gatsby-config.js",
   "author": "Robin Métral <robin@metral.ch>",


### PR DESCRIPTION
Also remove useWorkspaces flag from lerna config to prevent from attempting to publish the private example directory